### PR TITLE
Fix half-duplex hardware SPI

### DIFF
--- a/arduino/libraries/bc66/SPI/src/SPI.h
+++ b/arduino/libraries/bc66/SPI/src/SPI.h
@@ -77,6 +77,7 @@ class SPIClass
     bool _cpol;
     bool _cpha;
     bool _type;
+    bool _config;
 
     Enum_PinName _miso;
     Enum_PinName _mosi;


### PR DESCRIPTION
This change makes half-duplex hardware SPI work.
Tested with https://github.com/ZinggJM/GxEPD.git and NB-IoT-DevKit using Waveshare 1.5" e-paper on P3-P6 (HW SPI), P26(GPIO1), P30(GPIO2), P32(GPIO4).
