### PR TITLE
Add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "framework-quectel",
+    "description": "WizIO Frameworks for Quectel",
+    "url": "https://github.com/Wiz-IO/framework-quectel.git",
+    "system": "*",
+    "version": "2.0.20"
+}


### PR DESCRIPTION
Add package.json to permit use of `platform-quectel` with recent PlatformIO releases.